### PR TITLE
Feature/#12 gutenberg support

### DIFF
--- a/src/components/blocks/paragraph.js
+++ b/src/components/blocks/paragraph.js
@@ -1,0 +1,36 @@
+import React, { Component } from "react";
+import { graphql } from "gatsby";
+
+class Paragraph extends Component {
+  render() {
+    const data = this.props.block.attributes;
+    return (
+      <>
+        <p
+          className={data.className}
+          dangerouslySetInnerHTML={{ __html: data.content }}
+        />
+        {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
+      </>
+    );
+  }
+}
+
+export default Paragraph;
+
+export const query = graphql`
+  fragment ParagraphInfo on WordPress_CoreParagraphBlockAttributesV3 {
+    align
+    backgroundColor
+    content
+    className
+    customBackgroundColor
+    customFontSize
+    customTextColor
+    direction
+    dropCap
+    fontSize
+    placeholder
+    textColor
+  }
+`;

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -4,6 +4,7 @@ import Layout from "../components/layout";
 import SEO from "../components/seo";
 import Byline from "../components/byline";
 import Meta from "../components/meta";
+import Paragraph from "../components/blocks/paragraph";
 
 class PostTemplate extends Component {
   render() {
@@ -12,13 +13,21 @@ class PostTemplate extends Component {
 
     return (
       <Layout>
+        {/* <pre>{JSON.stringify(post, null, 2)}</pre> */}
         <SEO title={post.title} description={post.title} image={image} />
         <article id={post.id}>
           <header>
             <h1 dangerouslySetInnerHTML={{ __html: post.title }} />
             <Byline props={post} />
           </header>
-          <section dangerouslySetInnerHTML={{ __html: post.content }} />
+          {post.blocks.map(block => {
+            switch (block.__typename) {
+              case "WordPress_CoreParagraphBlock":
+                return <Paragraph block={block} />;
+              default:
+                return ``;
+            }
+          })}
           <footer>
             <Meta props={post} />
           </footer>
@@ -27,6 +36,8 @@ class PostTemplate extends Component {
     );
   }
 }
+
+function displayBlock(blockType) {}
 
 export default PostTemplate;
 
@@ -64,6 +75,16 @@ export const pageQuery = graphql`
               name
               id
               slug
+            }
+          }
+        }
+        blocks {
+          name
+          ... on WordPress_CoreParagraphBlock {
+            attributes {
+              ... on WordPress_CoreParagraphBlockAttributesV3 {
+                ...ParagraphInfo
+              }
             }
           }
         }


### PR DESCRIPTION
Closes #12 

Initial list
- [ ] Install [wp-graphql-gutenberg](https://github.com/pristas-peter/wp-graphql-gutenberg) installed on the demo [WordPress install](gregrickaby.blog)
- [ ] Create a `<Paragraph>` component
- [ ] Create GraphQL fragment
- [ ] Pass fragment into main query
- [ ] Use `switch` to determine the block, and then pull in the right `<Component>`

Once this passes testing, then move onto _all_ the Core Blocks

- [ ] Get a list of core blocks
- [ ] Create `<Component>` for each core block
- [ ] Ensure all props, for each `<Component>`
